### PR TITLE
setup.py: sklearn => scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='drep',
           'seaborn',
           'matplotlib',
           'biopython',
-          'sklearn',
+          'scikit-learn',
           'pytest'
       ],
       zip_safe=False)


### PR DESCRIPTION
'sklearn' is not the intended library.