### PR TITLE
force_overwrite in checkm

### DIFF
--- a/drep/d_filter.py
+++ b/drep/d_filter.py
@@ -497,11 +497,11 @@ def run_checkM(genome_folder,checkm_outf,**kwargs):
     # Run checkM initial
     if checkm_method == 'taxonomy_wf':
          cmd = [check_exe,checkm_method,'domain','Bacteria',genome_folder,checkm_outf,'-f',\
-            checkm_outf + '/results.tsv','--tab_table','-t',str(t),'-g','-x','faa']
+            checkm_outf + '/results.tsv','--tab_table','-t',str(t),'-g','-x','faa', '--force_overwrite']
     else:
          cmd = [check_exe,checkm_method,genome_folder,checkm_outf,'-f',\
             checkm_outf + '/results.tsv','--tab_table','-t',str(t),'--pplacer_threads',\
-            str(t),'-g','-x','faa']
+            str(t),'-g','-x','faa', '--force_overwrite']
 
     logging.debug("Running CheckM with command: {0}".format(cmd))
 


### PR DESCRIPTION
I added force_overwrite to checkm. If dRep fails in the middle of checkm, it will fail in the next try because checkm output dir is not empty