### PR TITLE
test for nan in strain_heterogeneity

### DIFF
--- a/drep/d_choose.py
+++ b/drep/d_choose.py
@@ -204,6 +204,19 @@ def score_genomes(genomes, Gdb, Edb=None, **kwargs):
     else:
         g2e = {}
 
+    # Test for NaNs in Gdb['strain_heterogeneity']
+
+    if Gdb['strain_heterogeneity'].isnull().values.any():
+        kwargs['strain_heterogeneity_weight'] = 0
+        logging.warning ('NaNs found in Gdb strain_heterogeneity! '
+                         'This may have happened if CheckM results '
+                         'were imported for some but not all '
+                         'genomes. \n\n'
+                         'Setting strain_heterogeneity_weight to zero')
+        Gdb.drop('strain_heterogeneity',
+                 axis=1,
+                 inplace=True)
+
     Table = {'genome':[],'score':[]}
     for genome in genomes:
         if genome in g2e:


### PR DESCRIPTION
Fixes issue #180 by checking the Gdb table for null values in the `strain_heterogeneity` column. If it finds any, it drops the column from the table and issues a warning, while setting the coefficient for that column in the score calculation to zero. 