### PR TITLE
Fix to issue #180: nan in strain_heterogeneity

### DIFF
--- a/drep/d_choose.py
+++ b/drep/d_choose.py
@@ -204,6 +204,18 @@ def score_genomes(genomes, Gdb, Edb=None, **kwargs):
     else:
         g2e = {}
 
+    # Test for NaNs in Gdb['strain_heterogeneity']
+    if 'strain_heterogeneity' in Gdb.columns:
+        if Gdb['strain_heterogeneity'].isnull().values.any():
+            kwargs['strain_heterogeneity_weight'] = 0
+            logging.warning ('NaNs found in Gdb strain_heterogeneity! '
+                             'This may have happened if CheckM results '
+                             'were imported for some but not all '
+                             'genomes. \n\n'
+                             'Setting strain_heterogeneity_weight to zero')
+            Gdb.drop('strain_heterogeneity',
+                     axis=1, inplace=True)
+
     Table = {'genome':[],'score':[]}
     for genome in genomes:
         if genome in g2e:


### PR DESCRIPTION
Fixes issue #180 by testing for presence of null values in `strain_heterogeneity` column of Gdb. If it finds null values, drops that column, sets the coefficient for strain heterogeneity to zero for purposes of score calculation, and issues a warning.